### PR TITLE
Don't let lingering data from previous requests interfere with the editing workflow

### DIFF
--- a/script/helpers.js
+++ b/script/helpers.js
@@ -26,6 +26,15 @@ function removeDiagramsEditor(handler) {
 }
 
 /**
+ * Explicitly disable caching of the AJAX request.
+ */
+function disableRequestCaching() {
+    jQuery.ajaxSetup({
+        cache: false,
+    });
+}
+
+/**
  * check if name/id of new diagram is valid
  *
  * @param id

--- a/script/helpers.js
+++ b/script/helpers.js
@@ -2,6 +2,30 @@ const serviceUrl = 'https://embed.diagrams.net/?embed=1&proto=json&spin=1';
 const doctypeXML = '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
 /**
+ * Return the diagrams editor object or false
+ * if it does not exist.
+ *
+ * @returns {boolean|WindowProxy}
+ */
+function getDiagramsEditor() {
+    const diagramsFrame = jQuery('#diagrams-frame');
+    if (diagramsFrame  && typeof diagramsFrame[0] !== 'undefined') {
+        return diagramsFrame[0].contentWindow;
+    }
+    return false;
+}
+
+/**
+ * Detach the message event handler and remove the editor
+ *
+ * @param handler
+ */
+function removeDiagramsEditor(handler) {
+    jQuery(window).off( 'message', handler );
+    jQuery('#diagrams-frame').remove();
+}
+
+/**
  * check if name/id of new diagram is valid
  *
  * @param id

--- a/script/service.js
+++ b/script/service.js
@@ -4,12 +4,17 @@
  * @param event
  */
 const handleServiceMessages = function( event ) {
+    const diagrams = getDiagramsEditor();
+    // early exit
+    if (!diagrams) {
+        return;
+    }
+
     // get diagram info passed to the function
     const fullId = event.data.fullId;
     const {ns, id} = splitFullId(fullId);
 
     const msg = JSON.parse( event.originalEvent.data );
-    const diagrams = jQuery( '#diagrams-frame' )[0].contentWindow;
     if( msg.event === 'init' ) {
         // try loading existing diagram file
         jQuery.get(DOKU_BASE + 'lib/exe/fetch.php?media=' + fullId, function (data) {
@@ -33,8 +38,6 @@ const handleServiceMessages = function( event ) {
                 } ).join( '' ) );
             jQuery.post( getLocalDiagramUrl(ns, id), datastr )
                 .done( function() {
-                    jQuery( window ).off( 'message', {fullId: fullId}, handleServiceMessages );
-                    jQuery( '#diagrams-frame' ).remove();
                     const url = new URL(location.href);
                     // media manager window should show current namespace
                     url.searchParams.set('ns', ns);
@@ -44,10 +47,12 @@ const handleServiceMessages = function( event ) {
                 })
                 .fail( function() {
                     alert( LANG.plugins.diagrams.errorSaving );
+                })
+                .always( function() {
+                    removeDiagramsEditor(handleServiceMessages);
                 });
         }
     } else if( msg.event === 'exit' ) {
-        jQuery( window ).off( 'message', {fullId: fullId}, handleServiceMessages );
-        jQuery( '#diagrams-frame' ).remove();
+        removeDiagramsEditor(handleServiceMessages);
     }
 };

--- a/script/service.js
+++ b/script/service.js
@@ -10,6 +10,9 @@ const handleServiceMessages = function( event ) {
         return;
     }
 
+    // some browsers stubbornly cache request data and mess up subsequent edits
+    disableRequestCaching();
+
     // get diagram info passed to the function
     const fullId = event.data.fullId;
     const {ns, id} = splitFullId(fullId);


### PR DESCRIPTION
This PR addresses two risks of data corruption when diagrams are edited in rapid succession:

1. Some old editors were not properly terminated and could overwrite their own files with the contents of the diagram being currently saved. So users could end up with `not_meant_to_update.svg` showing the same as `updated_and_correctly_saved.svg`
2. Caching of requests is explicitly disabled so that browsers do not send outdated  diagram data to the online editing service