### PR TITLE
Render SVGs as <object> instead of <img>

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,12 +3,12 @@ jQuery(function () {
     /* DOKUWIKI:include script/service.js */
     /* DOKUWIKI:include script/elements.js */
 
-    // add diagram edit button to all SVGs included in wiki pages
-    const $images = jQuery('img').filter('.media, .medialeft, .mediacenter, .mediaright');
+    // add diagram edit button to diagram SVGs included in wiki pages
+    const $images = jQuery('object').filter('.diagrams-svg');
 
     // collect image IDs with file extension
     const imageIds = $images.map(function (key, image) {
-        return extractIdFromMediaUrl(image.src);
+        return extractIdFromMediaUrl(image.data);
     }).toArray();
 
     let ajaxData = {};
@@ -19,7 +19,7 @@ jQuery(function () {
     const attachButtons = function (result) {
         const diagrams = JSON.parse(result);
         $images.each(function () {
-            const id = extractIdFromMediaUrl(this.src);
+            const id = extractIdFromMediaUrl(this.data);
             const $current = jQuery(this);
             if (diagrams.includes(id)) {
                 let $editButton = editDiagramButton(id);
@@ -109,5 +109,13 @@ jQuery(function () {
 
         const observer = new MutationObserver(addEditButton);
         observer.observe(targetNode, config);
+    });
+});
+
+// open links in diagrams in the browser window instead of SVG frame
+// TODO this will not work with DokuWiki master as of February 2021 (contentDocument is null)
+jQuery(window).on('load', function() {
+    jQuery('object.diagrams-svg').each( function() {
+        jQuery(this.contentDocument).find('svg').find('a').attr('target', '_parent');
     });
 });

--- a/syntax.php
+++ b/syntax.php
@@ -58,6 +58,7 @@ class syntax_plugin_diagrams extends DokuWiki_Syntax_Plugin {
         $renderer->doc .=
             '<object data="'
             . ml($data['src'])
+            . '&cache=nocache'
             .'" type="image/svg+xml" class="diagrams-svg media'
             . $data['align']
             .'" ></object>';

--- a/syntax.php
+++ b/syntax.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Class syntax_plugin_diagrams
+ */
+class syntax_plugin_diagrams extends DokuWiki_Syntax_Plugin {
+
+    /**
+     * @inheritdoc
+     */
+    public function getType()
+    {
+        return 'substition';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSort()
+    {
+        return 319;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function connectTo($mode)
+    {
+        $this->Lexer->addSpecialPattern('\{\{[^\}]+(?:\.svg)[^\}]*?\}\}',$mode,'plugin_diagrams');
+    }
+
+    /**
+     * Parse SVG syntax into media data
+     *
+     * @param string $match
+     * @param int $state
+     * @param int $pos
+     * @param Doku_Handler $handler
+     * @return array|bool
+     */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
+        return Doku_Handler_Parse_Media($match);
+    }
+
+    /**
+     * Render the diagram SVG as <object> instead of <img> to allow links
+     *
+     * @param string $format
+     * @param Doku_Renderer $renderer
+     * @param array $data
+     * @return bool
+     */
+    public function render($format, Doku_Renderer $renderer, $data)
+    {
+        if ($format !== 'xhtml') return false;
+
+        $renderer->doc .=
+            '<object data="'
+            . ml($data['src'])
+            .'" type="image/svg+xml" class="diagrams-svg media'
+            . $data['align']
+            .'" ></object>';
+
+        return true;
+    }
+}

--- a/syntax.php
+++ b/syntax.php
@@ -55,13 +55,11 @@ class syntax_plugin_diagrams extends DokuWiki_Syntax_Plugin {
     {
         if ($format !== 'xhtml') return false;
 
-        $renderer->doc .=
-            '<object data="'
-            . ml($data['src'])
-            . '&cache=nocache'
-            .'" type="image/svg+xml" class="diagrams-svg media'
-            . $data['align']
-            .'" ></object>';
+        $width = $data['width'] ? 'width="' . $data['width'] . '"' : '';
+        $height = $data['height'] ? 'height="' . $data['height'] . '"' : '';
+
+        $tag = '<object data="%s&cache=nocache" type="image/svg+xml" class="diagrams-svg media%s" %s %s></object>';
+        $renderer->doc .= sprintf($tag, ml($data['src']), $data['align'], $width, $height);
 
         return true;
     }


### PR DESCRIPTION
Inline SVGs can contain links.

The conversion from `img` to `object` still needs some refining.