### PR TITLE
Fix ACL checks in Media Manager Popup

### DIFF
--- a/action.php
+++ b/action.php
@@ -16,7 +16,8 @@ class action_plugin_diagrams extends DokuWiki_Action_Plugin
         $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'addJsinfo');
         $controller->register_hook('MEDIAMANAGER_STARTED', 'AFTER', $this, 'addJsinfo');
         $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'checkConf');
-        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjax');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjaxImages');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjaxAcl');
     }
 
     /**
@@ -49,9 +50,9 @@ class action_plugin_diagrams extends DokuWiki_Action_Plugin
      *
      * @param Doku_Event $event
      */
-    public function handleAjax(Doku_Event $event)
+    public function handleAjaxImages(Doku_Event $event)
     {
-        if ($event->data !== 'plugin_diagrams') return;
+        if ($event->data !== 'plugin_diagrams_images') return;
         $event->preventDefault();
         $event->stopPropagation();
 
@@ -59,6 +60,23 @@ class action_plugin_diagrams extends DokuWiki_Action_Plugin
         $images = $INPUT->arr('images');
 
         echo json_encode($this->editableDiagrams($images));
+    }
+
+    /**
+     * Check ACL for supplied namespace
+     *
+     * @param Doku_Event $event
+     */
+    public function handleAjaxAcl(Doku_Event $event)
+    {
+        if ($event->data !== 'plugin_diagrams_acl') return;
+        $event->preventDefault();
+        $event->stopPropagation();
+
+        global $INPUT;
+        $ns = $INPUT->str('ns');
+
+        echo json_encode(auth_quickaclcheck($ns . ':*') >= AUTH_UPLOAD);
     }
 
     /**

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -5,6 +5,7 @@ $lang['missingConfig'] = 'Fehlende Konfiguration für SVG Diagramme: Bitte "svg 
 $lang['js']['createButton'] = 'Erstellen';
 $lang['js']['createLink'] = 'Diagramm erstellen';
 $lang['js']['createIntro'] = 'Diagramm im aktuellen Namensraum erstellen:';
+$lang['js']['createForbidden'] = 'Sie besitzen nicht die notwendigen Berechtigungen';
 $lang['js']['editButton'] = 'Diagramm editieren';
 $lang['js']['errorInvalidId'] = 'Name ist leer oder enthält ungültige Zeichen!';
 $lang['js']['errorSaving'] = 'Fehler beim Speichern';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,6 +5,7 @@ $lang['missingConfig'] = 'Missing configuration for SVG diagrams: Remember to ad
 $lang['js']['createButton'] = 'Create';
 $lang['js']['createLink'] = 'Create a diagram';
 $lang['js']['createIntro'] = 'Create a diagram in current namespace';
+$lang['js']['createForbidden'] = 'You do not have sufficient permissions';
 $lang['js']['editButton'] = 'Edit diagram';
 $lang['js']['errorInvalidId'] = 'Name is empty or contains invalid characters!';
 $lang['js']['errorSaving'] = 'Saving failed';

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ jQuery(function () {
     }).toArray();
 
     let ajaxData = {};
-    ajaxData['call'] = 'plugin_diagrams';
+    ajaxData['call'] = 'plugin_diagrams_images';
     ajaxData['images'] = imageIds;
 
     // callback to attach buttons to editable diagrams
@@ -65,7 +65,24 @@ jQuery(function () {
                 open: function () {
                     const nsText = isMMPage ? jQuery('.panelHeader h3 strong').text() : jQuery('#media__ns').text();
                     const ns = cleanNs(nsText);
-                    jQuery('#diagrams__current-ns').text(ns);
+                    const $intro = jQuery('#diagrams__current-ns');
+                    $intro.text(ns);
+
+                    // check ACLs before displaying the form
+                    let ajaxData = {};
+                    ajaxData['call'] = 'plugin_diagrams_acl';
+                    ajaxData['ns'] = ns;
+                    jQuery.get(
+                        DOKU_BASE + 'lib/exe/ajax.php',
+                        ajaxData,
+                        function (result) {
+                            if (JSON.parse(result) !== true) {
+                                $intro.after('<br>' + LANG.plugins.diagrams.createForbidden);
+                                jQuery('#diagrams__create-filename').remove();
+                                jQuery('#diagrams__create').remove();
+                            }
+                        }
+                    );
                 },
                 close: function () {
                     // do not reuse the dialog

--- a/script/helpers.js
+++ b/script/helpers.js
@@ -48,7 +48,7 @@ function validId(id) {
  * because it is not a real namespace
  */
 function cleanNs (text) {
-    return text.replace(/^\[.*\]$/, '');
+    return text.replace(/^:|\[.*\]$/, '');
 }
 
 /**


### PR DESCRIPTION
This PR also introduces a more user friendly way to handle insufficient permissions. Instead of showing the editor and silently failing on save, we check early and remove the creation form.

Fixes the remaining issue in #17 and related #18