### PR TITLE
Adjust CSP to allow links

### DIFF
--- a/action.php
+++ b/action.php
@@ -90,6 +90,7 @@ class action_plugin_diagrams extends DokuWiki_Action_Plugin
     {
         if ($this->isDiagram($event->data['media'])) {
             $event->data['csp']['img-src'] = "self data:";
+            $event->data['csp']['sandbox'] = "allow-popups allow-top-navigation allow-same-origin";
         }
     }
 


### PR DESCRIPTION
Change the default `sandbox` directive because:
- it enforces same origin policy and prevents us from manipulating links via `object.contentDocument` (set the parent window as target)
- it prevents navigation via links

Fixes #5 and #15