### PR TITLE
Another fix for link target in diagrams

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,9 +14,4 @@ if (JSINFO.plugins.diagrams && (JSINFO.plugins.diagrams.mode & 2)) {
 }
 
 // open links in diagrams in the browser window instead of SVG frame
-jQuery(window).on('load', function () {
-    jQuery('object.diagrams-svg').each(function () {
-        jQuery(this.contentDocument).find('svg a').not('[target]').attr('target', '_top');
-    });
-});
-
+/* DOKUWIKI:include script/mediafile-linkfix.js */

--- a/script/mediafile-linkfix.js
+++ b/script/mediafile-linkfix.js
@@ -1,9 +1,16 @@
 /**
  * Open links in diagrams in the browser window instead of SVG frame
+ *
+ * FIXME wrapping the function in dokuwiki__content click handler
+ * is necessary for releases up to Jack, because hovering over
+ * section edit buttons used to remove handlers attached inside the section
  */
 window.addEventListener('load', () => {
-    document.querySelectorAll('object.diagrams-svg svg a').forEach(link => {
-        link.setAttribute('target', '_parent');
-        link.setAttribute('style', 'pointer-events: all;');
+    // FIXME workaround wrapper
+    document.querySelector('#dokuwiki__content').addEventListener('click', (event) => {
+        jQuery('object.diagrams-svg').each(function () {
+            jQuery(this.contentDocument).find('svg a').not('[target]').attr('target', '_top');
+        });
     });
+
 });


### PR DESCRIPTION
Link target rewrites happen on each click, not only on initial page load, because section edits destroy them.