### PR TITLE
Link target in SVG diagrams

### DIFF
--- a/script/mediafile-linkfix.js
+++ b/script/mediafile-linkfix.js
@@ -1,16 +1,47 @@
 /**
  * Open links in diagrams in the browser window instead of SVG frame
- *
- * FIXME wrapping the function in dokuwiki__content click handler
- * is necessary for releases up to Jack, because hovering over
- * section edit buttons used to remove handlers attached inside the section
  */
-window.addEventListener('load', () => {
-    // FIXME workaround wrapper
-    document.querySelector('#dokuwiki__content').addEventListener('click', (event) => {
+window.addEventListener('load', function () {
+    /**
+     * Sets _top target for links within SVG
+     */
+    function manipulateLinkTarget() {
         jQuery('object.diagrams-svg').each(function () {
             jQuery(this.contentDocument).find('svg a').not('[target]').attr('target', '_top');
         });
+    }
+
+    /* template agnostic selector */
+    const observable = document.querySelector('body');
+
+    const bodyObserver = new MutationObserver((mutationsList, observer) => {
+        for (const mutation of mutationsList) {
+            if (mutation.type !== 'childList') continue;
+
+            const nodes = mutation.addedNodes;
+
+            nodes.forEach(node => {
+                jQuery(node).find('object.diagrams-svg').each(function () {
+                    // SVG clicks do not bubble up, so we use an available event
+                    // FIXME this will not work on mobile devices
+                    jQuery(this).on('mouseover', manipulateLinkTarget);
+                });
+            });
+        }
     });
 
+    /* rewrite link targets when document is initially loaded */
+    manipulateLinkTarget();
+
+    /**
+     * Observe DOM changes
+     *
+     * FIXME this should no longer be necessary after Jack
+     * @see https://github.com/dokuwiki/dokuwiki/pull/3957
+     */
+    bodyObserver.observe(observable, {
+        attributes: true,
+        childList: true,
+        subtree: true }
+    );
 });

--- a/script/mediafile-linkfix.js
+++ b/script/mediafile-linkfix.js
@@ -23,8 +23,7 @@ window.addEventListener('load', function () {
             nodes.forEach(node => {
                 jQuery(node).find('object.diagrams-svg').each(function () {
                     // SVG clicks do not bubble up, so we use an available event
-                    // FIXME this will not work on mobile devices
-                    jQuery(this).on('mouseover', manipulateLinkTarget);
+                    jQuery(this).on('load', manipulateLinkTarget);
                 });
             });
         }


### PR DESCRIPTION
This PR attempts to rewrite link targets to _top on all `object.svg-diagram1 SVGs in rendered DokuWiki content, using a MutationObserver for diagrams re-added to DOM by section edit script (problem generally addressed in https://github.com/dokuwiki/dokuwiki/pull/3957)