### PR TITLE
Fix reloading page after editing a diagram

### DIFF
--- a/script/embed-editbutton.js
+++ b/script/embed-editbutton.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
         button.addEventListener('click', event => {
             event.preventDefault();
             const diagramsEditor = new DiagramsEditor(() => {
-                window.location.reload();
+                // replace instead of reload to avoid accidentally re-submitting forms
+                window.location.replace(window.location.href);
             });
             diagramsEditor.editEmbed(
                 JSINFO.id,

--- a/script/mediafile-editbutton.js
+++ b/script/mediafile-editbutton.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             button.addEventListener('click', event => {
                 event.preventDefault();
                 const diagramsEditor = new DiagramsEditor(() => {
-                    window.location.reload();
+                    // replace instead of reload to avoid accidentally re-submitting forms
+                    window.location.replace(window.location.href);
                 });
                 diagramsEditor.editMediaFile(image.getAttribute('data-id'));
             });


### PR DESCRIPTION
Use `replace()` instead of `reload()` to avoid accidentally re-submitting forms.